### PR TITLE
⚡ Switch to Turborepo for executing workspace scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
 name: Pull Request
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 on:
   push:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
 name: Pull Request
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
 on:
   workflow_dispatch:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,15 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn workspaces foreach --verbose --since run pre-commit
+# Since `--filter[HEAD^1]` doesn't seem to reproduce the behavior of `--since`
+# from Yarn 3, so this is a pretty silly amalgamation of the two tools
+function get_filters_for_changed_workspaces() {
+  yarn workspaces list --since \
+    | awk '{ print $3 }' \
+    | grep -v Done \
+    | awk -v d=" --filter=./" '{s=(s d)$0}END{print s}' \
+    | sed 's/\.\/\./\/\//'
+}
+
+# Caching doesn't seem to be working for this yet...
+yarn turbo pre-commit --concurrency=1 $(get_filters_for_changed_workspaces)

--- a/applications/emulator/package.json
+++ b/applications/emulator/package.json
@@ -18,8 +18,9 @@
     "start": "run-p 'start:*'",
     "start:source": "",
     "start:types": "tsc -b -w --preserveWatchOutput",
-    "test": "hover-scripts test",
-    "test:update": "hover-scripts test --updateSnapshot"
+    "test": "hover-scripts test --no-watch",
+    "test:update": "hover-scripts test --updateSnapshot",
+    "test:watch": "hover-scripts test"
   },
   "devDependencies": {
     "@hover/javascript": "7.0.0-beta.6",

--- a/applications/site/package.json
+++ b/applications/site/package.json
@@ -19,8 +19,9 @@
     "start": "run-p 'start:*'",
     "start:source": "next dev",
     "start:types": "tsc -b -w --preserveWatchOutput",
-    "test": "hover-scripts test",
-    "test:update": "hover-scripts test --updateSnapshot"
+    "test": "hover-scripts test --no-watch",
+    "test:update": "hover-scripts test --updateSnapshot",
+    "test:watch": "hover-scripts test"
   },
   "devDependencies": {
     "@hover/javascript": "7.0.0-beta.6",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,13 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "build:types": "yarn workspaces foreach -v run build:types",
+    "build": "turbo build:source --filter='./applications/*'",
+    "build:packages": "preconstruct build",
+    "build:types": "turbo build:types",
     "commit": "hover-scripts commit",
     "commit:install": "husky install",
-    "format": "yarn workspaces foreach -v run format",
-    "lint": "yarn workspaces foreach -pv run lint",
+    "format": "turbo format",
+    "lint": "turbo lint",
     "packages:check": "manypkg check",
     "packages:fix": "manypkg fix",
     "packages:link": "preconstruct dev",
@@ -24,7 +26,7 @@
     "start:site": "yarn workspace @jrolfs/site run start",
     "start:three": "yarn workspace @jrolfs/three run start",
     "start:types": "yarn workspaces foreach -v run start:types",
-    "test": "yarn workspaces foreach -v run test --no-watch"
+    "test": "turbo run test"
   },
   "dependencies": {
     "@hover/javascript": "7.0.0-beta.6",
@@ -34,7 +36,8 @@
     "@types/eslint": "^8.4.1",
     "husky": "^8.0.2",
     "npm-run-all": "^4.1.5",
-    "three": "^0.147.0"
+    "three": "^0.147.0",
+    "turbo": "^1.6.3"
   },
   "workspaces": [
     "applications/*",
@@ -49,5 +52,6 @@
     "@mdx-js/loader": "^2.1.5",
     "@mdx-js/react": "^2.1.5",
     "@types/react": "^18.0.26"
-  }
+  },
+  "packageManager": "yarn@3.1.1"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,8 +26,9 @@
     "start": "run-p 'start:*'",
     "start:source": "",
     "start:types": "tsc -b -w --preserveWatchOutput",
-    "test": "hover-scripts test",
-    "test:update": "hover-scripts test --updateSnapshot"
+    "test": "hover-scripts test --no-watch",
+    "test:update": "hover-scripts test --updateSnapshot",
+    "test:watch": "hover-scripts test"
   },
   "devDependencies": {
     "@hover/javascript": "7.0.0-beta.6",

--- a/packages/three/package.json
+++ b/packages/three/package.json
@@ -24,8 +24,9 @@
     "start": "run-p 'start:*'",
     "start:source": "start-storybook --ci -p 6006 -s assets",
     "start:types": "tsc -b -w --preserveWatchOutput",
-    "test": "hover-scripts test",
-    "test:update": "hover-scripts test --updateSnapshot"
+    "test": "hover-scripts test --no-watch",
+    "test:update": "hover-scripts test --updateSnapshot",
+    "test:watch": "hover-scripts test"
   },
   "peerDependencies": {
     "@react-spring/three": "^9.5.5",

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build:source": {
+      "outputs": [".next/**"],
+      "dependsOn": ["//#build:packages"]
+    },
+    "//#build:packages": {
+      "outputs": ["**/dist/**"]
+    },
+    "build:types": {
+      "outputs": [],
+      "dependsOn": ["^build:types"]
+    },
+    "format": { "outputs": [] },
+    "pre-commit": {
+      "inputs": [
+        "**/*.+(js|jsx|json|json5|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)"
+      ],
+      "outputs": []
+    },
+    "lint": { "outputs": [] },
+    "test": { "outputs": [] }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12583,6 +12583,7 @@ __metadata:
     husky: ^8.0.2
     npm-run-all: ^4.1.5
     three: ^0.147.0
+    turbo: ^1.6.3
   languageName: unknown
   linkType: soft
 
@@ -19003,6 +19004,77 @@ __metadata:
   version: 0.0.6
   resolution: "tunnel@npm:0.0.6"
   checksum: c362948df9ad34b649b5585e54ce2838fa583aa3037091aaed66793c65b423a264e5229f0d7e9a95513a795ac2bd4cb72cda7e89a74313f182c1e9ae0b0994fa
+  languageName: node
+  linkType: hard
+
+"turbo-darwin-64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-darwin-64@npm:1.6.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"turbo-darwin-arm64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-darwin-arm64@npm:1.6.3"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"turbo-linux-64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-linux-64@npm:1.6.3"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"turbo-linux-arm64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-linux-arm64@npm:1.6.3"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"turbo-windows-64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-windows-64@npm:1.6.3"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"turbo-windows-arm64@npm:1.6.3":
+  version: 1.6.3
+  resolution: "turbo-windows-arm64@npm:1.6.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"turbo@npm:^1.6.3":
+  version: 1.6.3
+  resolution: "turbo@npm:1.6.3"
+  dependencies:
+    turbo-darwin-64: 1.6.3
+    turbo-darwin-arm64: 1.6.3
+    turbo-linux-64: 1.6.3
+    turbo-linux-arm64: 1.6.3
+    turbo-windows-64: 1.6.3
+    turbo-windows-arm64: 1.6.3
+  dependenciesMeta:
+    turbo-darwin-64:
+      optional: true
+    turbo-darwin-arm64:
+      optional: true
+    turbo-linux-64:
+      optional: true
+    turbo-linux-arm64:
+      optional: true
+    turbo-windows-64:
+      optional: true
+    turbo-windows-arm64:
+      optional: true
+  bin:
+    turbo: bin/turbo
+  checksum: 35195f4b7623014c25ba152c11a8cb23e51cbd75dc9266d0656692665f85b28faf3496dea8cecacf52795a917410668124186ffbdcf276325ccc3e11df9e9623
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Add **turbo** and `turbo.json` pipeline definitions
- Add `build` script at root that uses **turbo** to execute Preconstruct build and then all application builds
- Switch all usages of `workspaces foreach` to use **turbo** 🏎️

#### Future
- Figure out how to use **turbo** to cache properly for `pre-commit` hooks across workspaces
